### PR TITLE
Add user rule func handling for catch-all all types fields.

### DIFF
--- a/src/index.php
+++ b/src/index.php
@@ -72,6 +72,11 @@ function handleRule($group, $rule, $options)
     if (isset($rule['rules'])) {
         return $rule;
     }
+    // Apply user func for field on any type if available.
+    if (isset($options['ruleFuncMap'][ALL_TYPES][$rule['field']])) {
+        $userFunc = $options['ruleFuncMap'][ALL_TYPES][$rule['field']];
+        return $userFunc($group, $rule, $options);
+    }
     // Apply user func to $rule if available
     if (isset($options['ruleFuncMap'][$group['QB']][$rule['field']])) {
         $userFunc = $options['ruleFuncMap'][$group['QB']][$rule['field']];

--- a/src/index.spec.php
+++ b/src/index.spec.php
@@ -1289,4 +1289,75 @@ final class IndexTest extends TestCase
 
         $this->assertEquals($query, Boolbuilder\transform($group, $options));
     }
+
+    public function testAllTypesUserRuleFunc()
+    {
+        $group = [
+            'condition' => 'OR',
+            'rules' => [
+                [
+                    'QB' => 'Message',
+                    'condition' => 'AND',
+                    'rules' => [
+                        [
+                            'field' => 'user',
+                            'type' => 'string',
+                            'operator' => 'contains',
+                            'value' => 'kimchy'
+                        ]
+                    ]
+                ],
+                [
+                    'QB' => 'Chat',
+                    'condition' => 'AND',
+                    'rules' => [
+                        [
+                            'field' => 'user',
+                            'type' => 'string',
+                            'operator' => 'contains',
+                            'value' => 'elasticsearch'
+                        ]
+                    ]
+                ]
+            ]
+        ];
+
+        $options = [];
+        $options['ruleFuncMap'] = [];
+        $options['ruleFuncMap']['*'] = [];
+        $options['ruleFuncMap']['*']['user'] = function ($group, $rule, $options) {
+            $rule['value'] = strtoupper($rule['value']);
+            return $rule;
+        };
+
+        $query = [
+            'bool' => [
+                'should' => [
+                    [
+                        'bool' => [
+                            'must' => [
+                                [
+                                    'match' => [
+                                        'user' => 'KIMCHY'
+                                    ]
+                                ]
+                            ]
+                        ]
+                    ],
+                    [
+                        'bool' => [
+                            'must' => [
+                                [
+                                    'match' => [
+                                        'user' => 'ELASTICSEARCH'
+                                    ]
+                                ]
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+        ];
+        $this->assertEquals($query, Boolbuilder\transform($group, $options));
+    }
 }


### PR DESCRIPTION
Allow for user function to be specified on rule(s) of any type. So, if types share a field name, a common func can be applied to it once.